### PR TITLE
ci(docker-compose): Publish Docker Compose OCI artifact to ghcr.

### DIFF
--- a/.github/workflows/spider-compose.yaml
+++ b/.github/workflows/spider-compose.yaml
@@ -1,0 +1,72 @@
+name: "spider-compose"
+
+on:
+  pull_request:
+    paths: &monitored_paths
+      - ".github/workflows/spider-compose.yaml"
+      - "taskfile.yaml"
+      - "taskfiles/docker.yaml"
+      - "tools/deployment/spider-compose/**"
+      - "tools/yscope-dev-utils"
+  push:
+    branches: ["main"]
+    paths: *monitored_paths
+    tags: ["spider-huntsman-v*"]
+  workflow_dispatch:
+
+permissions: {}
+
+concurrency:
+  group: "${{github.workflow}}-${{github.ref}}"
+
+  # Cancel in-progress jobs for efficiency. Exclude published refs to allow uninterrupted
+  # publishing of Compose applications.
+  cancel-in-progress: >-
+    ${{
+      github.ref != 'refs/heads/main'
+      && !startsWith(github.ref, 'refs/tags/spider-huntsman-v')
+    }}
+
+jobs:
+  validate:
+    runs-on: "ubuntu-latest"
+    steps:
+      - uses: "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1"  # v7.0.1
+        with:
+          submodules: "recursive"
+
+      - uses: "./tools/yscope-dev-utils/exports/github/actions/install-go-task"
+        with:
+          version: "3.48.0"
+
+      - name: "Validate OCI Compose application"
+        run: "task docker:compose:validate"
+
+  publish:
+    if: "github.event_name != 'pull_request'"
+    needs: "validate"
+    runs-on: "ubuntu-latest"
+    permissions:
+      contents: "read"
+      packages: "write"
+    steps:
+      - uses: "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1"  # v7.0.1
+
+      - uses: "docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121"  # v4.1.0
+        with:
+          registry: "ghcr.io"
+          username: "${{github.actor}}"
+          password: "${{secrets.GITHUB_TOKEN}}"
+
+      - name: "Publish Compose application"
+        shell: "bash"
+        working-directory: "tools/deployment/spider-compose"
+        run: |-
+          repository="ghcr.io/${GITHUB_REPOSITORY,,}/compose"
+          if [[ "$GITHUB_REF" == refs/tags/spider-huntsman-v* ]]; then
+            artifact_tag="$GITHUB_REF_NAME"
+          else
+            artifact_tag="nightly"
+          fi
+          docker compose --env-file .env.example --file compose.yaml publish \
+            --yes "${repository}:${artifact_tag}"

--- a/taskfiles/docker.yaml
+++ b/taskfiles/docker.yaml
@@ -25,11 +25,16 @@ tasks:
 
   compose:validate:
     dir: "{{.G_SPIDER_COMPOSE_DIR}}"
-    cmd: "docker compose --file compose.yaml config --quiet"
+    cmd: >-
+      docker compose --env-file .env.example --file compose.yaml publish
+      --dry-run --yes ghcr.io/y-scope/spider/compose:validation
 
   compose:up:
+    dotenv: ["{{.G_SPIDER_COMPOSE_DIR}}/.env"]
     dir: "{{.G_SPIDER_COMPOSE_DIR}}"
-    cmd: "docker compose --file compose.yaml up --detach --wait"
+    cmd: >-
+      docker compose --file compose.yaml up --detach --wait
+      --scale "spider-worker=${SPIDER_WORKER_REPLICAS:-1}"
 
   compose:down:
     dir: "{{.G_SPIDER_COMPOSE_DIR}}"
@@ -41,6 +46,7 @@ tasks:
 
   compose:local:up:
     deps: ["build"]
+    dotenv: ["{{.G_SPIDER_COMPOSE_DIR}}/.env.example"]
     dir: "{{.G_SPIDER_COMPOSE_DIR}}"
     cmd: >-
       SPIDER_PULL_POLICY="never"
@@ -48,6 +54,7 @@ tasks:
       SPIDER_STORAGE_IMAGE_REF="$(cat '{{.ROOT_DIR}}/build/spider-storage-image.id')"
       SPIDER_WORKER_IMAGE_REF="$(cat '{{.ROOT_DIR}}/build/spider-worker-image.id')"
       docker compose --env-file .env.example up --detach --wait
+      --scale "spider-worker=${SPIDER_WORKER_REPLICAS:-1}"
 
   compose:local:down:
     dir: "{{.G_SPIDER_COMPOSE_DIR}}"

--- a/tools/deployment/spider-compose/compose.yaml
+++ b/tools/deployment/spider-compose/compose.yaml
@@ -124,8 +124,6 @@ services:
       spider-storage:
         condition: "service_healthy"
         restart: true
-    deploy:
-      replicas: "${SPIDER_WORKER_REPLICAS:-4}"
 
 configs:
   spider-scheduler-config:

--- a/tools/deployment/spider-helm/Chart.yaml
+++ b/tools/deployment/spider-helm/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: "v2"
 name: "spider"
 description: "A Helm chart for the Spider Huntsman deployment"
 type: "application"
-version: "0.1.8"
+version: "0.1.9"
 appVersion: "0.1.0-dev"
 home: "https://github.com/y-scope/spider"
 sources: ["https://github.com/y-scope/spider"]

--- a/tools/deployment/spider-helm/values.yaml
+++ b/tools/deployment/spider-helm/values.yaml
@@ -41,8 +41,8 @@ spiderConfig:
   execution_manager:
     connection_pool_size: 4
     liveness:
-      scheduler_heartbeat_interval_sec: 10
-      storage_heartbeat_interval_sec: 10
+      scheduler_heartbeat_interval_sec: 1
+      storage_heartbeat_interval_sec: 1
     log_level: "INFO"
     scheduler_poll_wait_ms: 1000
     task_executor:
@@ -59,12 +59,12 @@ spiderConfig:
       scheduler:
         policy: "round_robin"
         config:
-          active_job_queue_capacity: 64
+          active_job_queue_capacity: 16
           cleanup_ready_task_capacity: 256
           commit_ready_task_capacity: 256
-          dispatch_queue_capacity: 64
+          dispatch_queue_capacity: 16
           finalizing_job_expiration_timeout_sec: 300
-          ready_task_capacity: 65536
+          ready_task_capacity: 1048576
           storage_poll_timeout_ms: 10
           tick_interval_ms: 5
 


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->
This PR:
- Fixes the number interpolation for worker replicas by moving it from Docker Compose file into startup tasks.
- Changes `docker:compose:validate` task to use OCI publish dry-run to validate OCI packaging.
- Adds a GitHub workflow to validate and publish Docker Compose OCI application to ghcr.
  - Publish `main` and manually triggered runs with `nightly` tag.
  - Publish `spider-huntsman-v*` releases with their corresponding Git tag.


# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->
* [ ] Docker compose workflow on [`main`](https://github.com/sitaowang1998/spider/actions/runs/31293579240) passed and OCI image published as expected.
* [ ] GitHub workflows pass.



[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html
